### PR TITLE
Use binaries in query funs

### DIFF
--- a/src/lmug-mw-content-type.lfe
+++ b/src/lmug-mw-content-type.lfe
@@ -8,7 +8,7 @@
 
 (defun wrap (handler)
   "The same as #'wrap/2 but with an empty list for options."
-  (wrap handler '()))
+  (wrap handler ()))
 
 (defun wrap (handler opts)
   "Middleware that adds a content-type header to the response if one is not
@@ -31,7 +31,7 @@
 
 (defun add-content-type (req resp)
   "The same as #'add-content-type/3 but with an empty list for options."
-  (add-content-type req resp '()))
+  (add-content-type req resp ()))
 
 (defun add-content-type
   "Adds a content-type header to the response. Used by ``#'wrap/2``.

--- a/src/lmug-mw-identity.lfe
+++ b/src/lmug-mw-identity.lfe
@@ -5,7 +5,7 @@
 
 (defun wrap (handler)
   "The same as #'wrap/2 but with an empty list for options."
-  (wrap handler '()))
+  (wrap handler ()))
 
 (defun wrap (handler _)
   "Middleware that does absolutely nothing at all."

--- a/src/lmug-opt.lfe
+++ b/src/lmug-opt.lfe
@@ -3,7 +3,7 @@
   (export all))
 
 (defun get (opts key)
-  (get opts key '()))
+  (get opts key ()))
 
 (defun get (opts key default)
   (case (proplists:get_value key opts)

--- a/src/lmug-request.lfe
+++ b/src/lmug-request.lfe
@@ -8,7 +8,7 @@
   "Create a default request suitable for use by lmug handlers.
 
   Returns an lmug ``request`` record."
-  (request '()))
+  (request ()))
 
 (defun request (opts)
   "Create a default request suitable for use by lmug handlers. The
@@ -42,20 +42,20 @@
     server-name (lmug-opt:get opts 'server-name #"")
     remote-addr (lmug-opt:get opts 'remote-addr 'undefined)
     uri (lmug-opt:get opts 'uri #"")
-    path (lmug-opt:get opts 'path '())
+    path (lmug-opt:get opts 'path ())
     query-string (lmug-opt:get opts 'query-string #"")
-    query-params (lmug-opt:get opts 'query-params '())
-    form-params (lmug-opt:get opts 'form-params '())
-    params (lmug-opt:get opts 'params '())
+    query-params (lmug-opt:get opts 'query-params ())
+    form-params (lmug-opt:get opts 'form-params ())
+    params (lmug-opt:get opts 'params ())
     scheme (lmug-opt:get opts 'scheme 'http)
     method (lmug-opt:get opts 'method 'get)
     ssl-client-cert (lmug-opt:get opts 'ssl-client-cert 'undefined)
-    headers (headers '() '(#"Content-Type"
+    headers (headers () '(#"Content-Type"
                            #"Content-Length"
                            #"Content-Encoding"))
     body (lmug-opt:get opts 'body #"")
     orig (lmug-opt:get opts 'orig 'undefined)
-    mw-data (lmug-opt:get opts 'mw-data '())))
+    mw-data (lmug-opt:get opts 'mw-data ())))
 
 (defun set-data (req key value)
   "Returns an updated lmug request with the ``mw-data`` field updated with

--- a/src/lmug-response.lfe
+++ b/src/lmug-response.lfe
@@ -10,7 +10,7 @@
   middleware chain, only at the beginning.
 
   Returns a function which expects an lmug request as the only argument."
-  (response 'undefined '()))
+  (response 'undefined ()))
 
 (defun response (_handler)
   "Create a default response suitable for use as an lmug handler. This
@@ -22,7 +22,7 @@
   should almost never need to use this function directly.
 
   Returns a function which expects an lmug request as the only argument."
-  (response _handler '()))
+  (response _handler ()))
 
 (defun response (_handler opts)
   "Create a default response suitable for use as an lmug handler. This
@@ -44,7 +44,7 @@
   (lambda (_req)
     (make-response
       status (lmug-opt:get opts 'status 200)
-      headers (lmug-opt:get opts 'headers '())
+      headers (lmug-opt:get opts 'headers ())
       body (lmug-opt:get opts 'body #""))))
 
 (defun header (resp header-key header-value)
@@ -72,7 +72,7 @@
 (defun match-header (headers header-key)
   "Return the first header that matches the given header-key."
   (case (match-headers headers header-key)
-    ('() #"")
+    (() #"")
     (headers (car headers))))
 
 (defun match-headers (headers sought-key)

--- a/src/lmug-util.lfe
+++ b/src/lmug-util.lfe
@@ -34,14 +34,15 @@
     hostname))
 
 (defun split-query (url)
-  (string:tokens url "?"))
+  (binary:split url #"?"))
 
 (defun parse-query-string (url)
   (case (split-query url)
     (`(,host ,query)
-      (httpd:parse_query query))
+     (lc ((<- `#(,k ,v) (httpd:parse_query query)))
+       `#(,(->binary k) ,(->binary v))))
     (`(,host)
-      '())))
+     ())))
 
 (defun httpd->lmug-request (data)
   "Every web server that gets an lmug adapter needs to implement a function
@@ -50,7 +51,7 @@
   defined in the lmug Spec)."
   (let ((`(,host ,port) (get-host-data (mod-absolute_uri data)))
         (remote-host (get-hostname (mod-init_data data)))
-        (uri (mod-request_uri data))
+        (uri (->binary (mod-request_uri data)))
         (body (mod-entity_body data)))
     (make-request
       server-port port
@@ -197,3 +198,7 @@
     #(.xpm      #"image/x-xpixmap")
     #(.xwd      #"image/x-xwindowdump")
     #(.zip      #"application/zip")))
+
+(defun ->binary
+  ([string] (when (is_list string)) (list_to_binary string))
+  ([bin]    (when (is_binary bin))  bin))

--- a/src/lmug-util.lfe
+++ b/src/lmug-util.lfe
@@ -95,7 +95,7 @@
 (defun ext->mime-type (ext)
   "The same as #'ext->mime-type/2 but with an empty list for optional
   mime-types."
-  (ext->mime-type ext '()))
+  (ext->mime-type ext ()))
 
 (defun ext->mime-type
   "Get the mimetype from the filename extension. Takes an optional proplist of

--- a/test/lmug-opt-tests.lfe
+++ b/test/lmug-opt-tests.lfe
@@ -14,7 +14,7 @@
   (is-equal 1 (lmug-opt:get (test-data) 'a))
   (is-equal 2 (lmug-opt:get (test-data) 'b))
   (is-equal 3 (lmug-opt:get (test-data) 'c))
-  (is-equal '() (lmug-opt:get (test-data) 'z)))
+  (is-equal () (lmug-opt:get (test-data) 'z)))
 
 (deftest get-with-defaults
   (is-equal 1 (lmug-opt:get (test-data) 'a 0))


### PR DESCRIPTION
This PR will fix #33. N.B. I also replaced all instances of `'()` with `()`, since there's no need to quote the empty list.
