### PR TITLE
Update src/lmug-util.lfe docs/SPEC.md

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -119,8 +119,8 @@ corresponding values:
 
 ```
 'method
-  (Required, 'options' | 'get' | 'head' | 'post' |
-             'put' | 'delete' | 'trace'
+  (Required, 'get' | 'head' | 'post' | 'put' | 'delete' |
+             'trace' | 'options' | 'connect' | 'patch'
   The HTTP request method, must be a lowercase atom corresponding to a
   HTTP request method, such as 'get or 'post.
 

--- a/src/lmug-util.lfe
+++ b/src/lmug-util.lfe
@@ -13,11 +13,21 @@
   (++ (lutil:get-version)
       `(#(lmug ,(get-lmug-version)))))
 
+(defun http-verbs ()
+  "The list of allowed HTTP verbs. See doc/spec.md for more info."
+  '(get head post put delete trace options connect patch))
+
 (defun normalize-http-verb
+  ((verb) (when (is_binary verb))
+   (normalize-http-verb (binary_to_list verb)))
   ((verb) (when (is_list verb))
-    (list_to_atom (string:to_lower verb)))
+   (validate-http-verb (list_to_atom (string:to_lower verb))))
   ((verb) (when (is_atom verb))
-    (normalize-http-verb (atom_to_list verb))))
+   (normalize-http-verb (atom_to_list verb))))
+
+(defun validate-http-verb (verb)
+  "If a given verb is valid, return it, otherwise throw an error."
+  (if (lists:member verb (http-verbs)) verb (error `#(invalid-verb ,verb))))
 
 (defun split-host-data (host-data)
   (binary:split (car (filename:split host-data)) #":"))


### PR DESCRIPTION
Add http-verbs/0 (the list of allowed verbs) and update
normalize-http-verb/1 per discussion and also validate the results
via the new validate-http-verb/1.

Define http-verbs/0 and update docs/SPEC.md based on the list here:
https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods

This PR will fix #32.
